### PR TITLE
CDP/LLDP now works with WLAN Pi v2 and added neighbour SW version info

### DIFF
--- a/BakeBit/Software/Python/scripts/networkinfo/networkinfo.sh
+++ b/BakeBit/Software/Python/scripts/networkinfo/networkinfo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#Keeps an eye on the syslog for eth0 up and down events and triggers networkinfo (i.e. LLDP) scripts
+
+DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+#Start neighbour detection immediately after the WLAN Pi boots up
+sudo "$DIRECTORY"/lldpneigh.sh &
+sudo "$DIRECTORY"/cdpneigh.sh  &
+
+#Monitor up/down status changes of eth0 and execute neighbour detection or cleanup
+tail -fn0 /var/log/messages |
+while read -r line
+do
+  case "$line" in
+  *".ethernet eth0: Link is Up"*)
+    logger "networkinfo script: eth0 went up"
+    #Execute neighbour detection scripts
+    sudo "$DIRECTORY"/lldpneigh.sh &
+    sudo "$DIRECTORY"/cdpneigh.sh  &
+  ;;
+  *".ethernet eth0: Link is Down"*)
+    logger "networkinfo script: eth0 went down"
+    #Execute cleanup scripts
+    sudo "$DIRECTORY"/lldpcleanup.sh
+    sudo "$DIRECTORY"/cdpcleanup.sh
+    #Kill any running instances of the CDP and LLDP scripts
+    pgrep cdpneigh.sh | xargs sudo pkill -P 2>/dev/null
+    pgrep lldpneigh.sh | xargs sudo pkill -P 2>/dev/null
+  ;;
+  *)
+  esac
+done


### PR DESCRIPTION
**CDP/LLDP neighbour detection**

- now displays SW version of neighbour
- OLED shows up to 5 lines of output (useful for SW version)
- renamed networkinfocron.sh to networkinfo.sh
- networkinfo.sh does not require any argument now (needed script path as argument in the past)