### PR TITLE
fix --clean arg when profiler2 is installed via pipx

### DIFF
--- a/BakeBit/Software/Python/modules/apps.py
+++ b/BakeBit/Software/Python/modules/apps.py
@@ -151,7 +151,7 @@ class App(object):
             self.simple_table_obj. display_dialog_msg(g_vars, "Please wait...", back_button_req=0)
 
             try:
-                cmd = "/usr/bin/python3 -m profiler2 --clean"
+                cmd = "profiler --clean"
                 subprocess.run(cmd, shell=True)
                 dialog_msg = "Reports purged."
             except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
when profiler2 package will be installed with pipx, the profiler package is not placed in `/usr/bin` and instead placed in `/opt/wlanpi/pipx/bin`. 

this PR is to make --clean work from FPMS once @crvallance's pipx PR [#3](https://github.com/danielmundi/build/pull/3) is merged into [build](https://github.com/danielmundi/build).

addt. minor clarification: the `console_script` entry point is `profiler` - this means `profiler2` will not launch the package.