### PR TITLE
Protection against multiple IPs assigned to the same interface - "Eth0 IP Config" and "Reachability"

### DIFF
--- a/BakeBit/Software/Python/scripts/networkinfo/ipconfig.sh
+++ b/BakeBit/Software/Python/scripts/networkinfo/ipconfig.sh
@@ -13,8 +13,8 @@ else
     ETH0LEASES="/var/lib/dhcp/dhclient.eth0.leases"
 fi
 
-ACTIVEIP=$(ip a | grep "eth0" | grep "inet" | grep -v "secondary" | cut -d '/' -f1 | cut -d ' ' -f6)
-SUBNET=$(ip a | grep "eth0" | grep "inet" | cut -d ' ' -f6 | tail -c 4)
+ACTIVEIP=$(ip a | grep "eth0" | grep "inet" | grep -v "secondary" | head -n1 | cut -d '/' -f1 | cut -d ' ' -f6)
+SUBNET=$(ip a | grep "eth0" | grep "inet" | grep -v "secondary" | head -n1 | cut -d ' ' -f6 | tail -c 4)
 
 LEASEDIPISUSED=$(grep "$ACTIVEIP" "$ETH0LEASES")
 

--- a/BakeBit/Software/Python/scripts/networkinfo/ipconfig.sh
+++ b/BakeBit/Software/Python/scripts/networkinfo/ipconfig.sh
@@ -3,23 +3,33 @@
 #Displays IP address, subnet mask, default gateway, DNS servers, speed, duplex, DHCP server IP address and name 
 
 #NetworkManager uses this location - WLAN Pi v1.x used /var/lib/dhcp/dhclient.eth0.leases
-ETH0UUID=$(nmcli -g connection.uuid connection show "Ifupdown (eth0)")
-ETH0LEASES="/var/lib/NetworkManager/dhclient-"$ETH0UUID"-eth0.lease"
+ETH0UUID=$(nmcli -f DEVICE,UUID connection show | grep "eth0" | cut -d" " -f5)
+ETH0UUIDLENGTH=$(echo "$ETH0UUID" | wc -l)
+if [ "$ETH0UUIDLENGTH" == "1" ]; then
+    #In this case NetworkManager was actually used to request IP address from DHCP server 
+    ETH0LEASES="/var/lib/NetworkManager/dhclient-"$ETH0UUID"-eth0.lease"
+else
+    #NetworkManager is not running properly for eth0, falling back to /etc/network/interfaces configuration, check that all references to eth0 in /etc/network/interfaces are removed and that NetworkManager services started
+    ETH0LEASES="/var/lib/dhcp/dhclient.eth0.leases"
+fi
 
-ACTIVEIP=$(ip a | grep "eth0" | grep "inet" | cut -d '/' -f1 | cut -d ' ' -f6)
+ACTIVEIP=$(ip a | grep "eth0" | grep "inet" | grep -v "secondary" | cut -d '/' -f1 | cut -d ' ' -f6)
 SUBNET=$(ip a | grep "eth0" | grep "inet" | cut -d ' ' -f6 | tail -c 4)
 
 LEASEDIPISUSED=$(grep "$ACTIVEIP" "$ETH0LEASES")
 
 ETH0ISUP=$(/sbin/ifconfig eth0 | grep "RUNNING")
-DHCPENABLED=$(grep -i "eth0" /etc/network/interfaces | grep "dhcp" | grep -v "#")
+
+#Not used by NetworkManager
+#DHCPENABLED=$(grep -i "eth0" /etc/network/interfaces | grep "dhcp" | grep -v "#")
+
 DHCPSRVNAME=$(grep -A 13 'interface "eth0"' "$ETH0LEASES" | tail -13 | grep -B 1 -A 10 "$ACTIVEIP" | grep "server-name" | cut -d '"' -f2)
 DHCPSRVADDR=$(grep -A 13 'interface "eth0"' "$ETH0LEASES" | tail -13 | grep -B 1 -A 10 "$ACTIVEIP" | grep "dhcp-server-identifier" | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}")
 DOMAINNAME=$(grep -A 13 'interface "eth0"' "$ETH0LEASES" | tail -13 | grep -B 1 -A 10 "$ACTIVEIP" | grep "domain-name " | cut -d '"' -f2)
 DEFAULTGW=$(/sbin/route -n | grep G | grep eth0 | cut -d ' ' -f 10)
 SPEED=$(ethtool eth0 | grep -q "Link detected: yes" && ethtool eth0 | grep "Speed" | sed 's/....$//' | cut -d ' ' -f2  || echo "Disconnected")
 DUPLEX=$(ethtool eth0 | grep -q "Link detected: yes" && ethtool eth0 | grep "Duplex" | cut -d ' ' -f 2 || echo "Disconnected")
-DNSSERVERS=$(cat /etc/resolv.conf | grep nameserver | cut -d ' ' -f2)
+DNSSERVERS=$(grep "nameserver" /etc/resolv.conf | sed 's/nameserver/DNS:/g')
 
 if [ "$ETH0ISUP" ]; then
     #IP address
@@ -32,12 +42,10 @@ if [ "$ETH0ISUP" ]; then
     echo "DG: $DEFAULTGW"
 
     #DNS servers
-    for n in "$DNSSERVERS"; do
-        echo "DNS: $n"
-    done
+    echo "$DNSSERVERS"
 
     #DHCP server info
-    if [[ "$LEASEDIPISUSED" ]] && [[ "$DHCPENABLED" ]] && [[ "$ACTIVEIP" ]]; then
+    if [[ "$LEASEDIPISUSED" ]] && [[ "$ACTIVEIP" ]]; then
         if [[ "$DHCPSRVNAME" ]] && [[ "$LEASEDIPISUSED" ]]; then
             echo "DHCP server name: $DHCPSRVNAME"
         fi
@@ -60,3 +68,4 @@ if [ "$ETH0ISUP" ]; then
 else
     echo "eth0 is down"
 fi
+

--- a/BakeBit/Software/Python/scripts/networkinfo/reachability.sh
+++ b/BakeBit/Software/Python/scripts/networkinfo/reachability.sh
@@ -10,8 +10,8 @@ cleanup
 
 # --- Variables ---
 TMPDIR="/tmp/reachability"
-DEFAULTGATEWAY=$(ip route | grep "default" | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}")
-DGINTERFACE=$(ip route | grep "default" | cut -d ' ' -f5)
+DEFAULTGATEWAY=$(ip route | grep "default" | grep -E -o "([0-9]{1,3}[\.]){3}[0-9]{1,3}" | head -n1)
+DGINTERFACE=$(ip route | grep "default" | head -n1 | cut -d ' ' -f5)
 DNSSERVERCOUNT=$(cat /etc/resolv.conf | grep "nameserver" | cut -d ' ' -f2 | wc -l)
 
 if [ "$DNSSERVERCOUNT" -eq 1 ]; then


### PR DESCRIPTION
Migration task raised to remove all references to eth0 from /etc/network/interfaces, which is the root cause.