### PR TITLE
profiler2 pipx path issues

### DIFF
--- a/BakeBit/Software/Python/modules/apps.py
+++ b/BakeBit/Software/Python/modules/apps.py
@@ -72,6 +72,7 @@ class App(object):
             return
         
         # get path to the config file
+        sys.path.append('/opt/wlanpi/pipx/venvs/profiler2/lib/python3.7/site-packages')
         package = pkgutil.get_loader("profiler2")
         entry_point = package.get_filename()
         profiler_dir = os.path.split(entry_point)[0]
@@ -151,7 +152,7 @@ class App(object):
             self.simple_table_obj. display_dialog_msg(g_vars, "Please wait...", back_button_req=0)
 
             try:
-                cmd = "profiler --clean"
+                cmd = "/opt/wlanpi/pipx/bin/profiler --clean --yes"
                 subprocess.run(cmd, shell=True)
                 dialog_msg = "Reports purged."
             except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
1. it appears fpms is run from the system python and has no knowledge of pipx profiler2 package. appending the path manually is a possible work around but i'm not sure this is the right approach ... perhaps @crvallance has some ideas on how to better solve this.

2. when testing it appears i had to add `/opt/wlanpi/pipx/bin/profiler` in the purge action for it to work.

3. in the previous PR #8 - i forgot about prompting the user to give y/n when running --clean. this was preventing the purge action from deleting files. i added an `--yes` arg to profiler2 to bypass this.

4. `profiler_ctl_file_update` does not seem to be updating the config.ini when starting with no11r or no11ax

we may need to discuss further on Slack before merging.