### PR TITLE
import sys for appending profiler pipx path

### DIFF
--- a/BakeBit/Software/Python/modules/apps.py
+++ b/BakeBit/Software/Python/modules/apps.py
@@ -3,6 +3,7 @@ import os.path
 import subprocess
 import pkgutil
 import bakebit_128_64_oled as oled
+import sys
 
 from modules.pages.simpletable import SimpleTable
 


### PR DESCRIPTION
without importing `sys`, line 75 throws an exception which locks the FPMS. this is my mistake, i should have caught this during the previous PR which added line 75 (:  