### PR TITLE
Add links to network info scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ SRCS := $(wildcard Source/*.c)
 install_data_dir = $(DESTDIR)$(datadir)/fpms
 install_bin_dir = $(DESTDIR)$(bindir)
 
+networkinfo_rel_dir = share/fpms/BakeBit/Software/Python/scripts/networkinfo
+
 binary_name=NanoHatOLED
 
 SERVICE_SUBS = \
@@ -39,7 +41,7 @@ fpms.service: fpms.service.in
 	@echo "Set the prefix on fpms.service"
 	sed -e '$(SERVICE_SUBS)' $< > $@
 
-install: installdirs $(binary_name) oled-start fpms.service
+install: installdirs $(binary_name) oled-start fpms.service networkinfo-links
 	cp -rf $(filter-out debian fpms.service.in $^,$(wildcard *)) $(install_data_dir)
 	install oled-start $(install_bin_dir)
 	install $(binary_name) $(install_bin_dir)
@@ -49,6 +51,14 @@ installdirs:
 	mkdir -p $(install_bin_dir) \
 		$(install_data_dir) \
 		$(DESTDIR)/lib/systemd/system
+
+networkinfo-links:
+	ln -fs ../$(networkinfo_rel_dir)/reachability.sh $(install_bin_dir)/reachability
+	ln -fs ../$(networkinfo_rel_dir)/publicip.sh $(install_bin_dir)/publicip
+	ln -fs ../$(networkinfo_rel_dir)/watchinternet.sh $(install_bin_dir)/watchinternet
+	ln -fs ../$(networkinfo_rel_dir)/telegrambot.sh $(install_bin_dir)/telegrambot
+	ln -fs ../$(networkinfo_rel_dir)/ipconfig.sh $(install_bin_dir)/ipconfig
+	ln -fs ../$(networkinfo_rel_dir)/portblinker.sh $(install_bin_dir)/portblinker
 
 clean:
 	-rm -f $(binary_name)
@@ -60,4 +70,10 @@ distclean: clean
 uninstall:
 	-rm -rf $(install_data_dir) \
 		$(install_bin_dir)/oled-start \
-		$(DESTDIR)/lib/systemd/system
+		$(DESTDIR)/lib/systemd/system \
+		$(bindir)/reachability \
+		$(bindir)/publicip \
+		$(bindir)/watchinternet \
+		$(bindir)/telegrambot \
+		$(bindir)/ipconfig \
+		$(bindir)/portblinker


### PR DESCRIPTION
Add relative symlinks to networkinfo scripts on bin directory.

Signed-off-by: Daniel Finimundi <daniel@finimundi.com>